### PR TITLE
major update. renaming of module and description

### DIFF
--- a/draft-zhu-rmcat-framework-00.txt
+++ b/draft-zhu-rmcat-framework-00.txt
@@ -1,504 +1,410 @@
-
-
-
-
-RMCAT WG                                                          X. Zhu
-Internet-Draft                                             Cisco Systems
-Intended status: Informational                                 Z. Sarker
-Expires: January 2, 2017                                     Ericsson AB
-                                                            July 1, 2016
-
-
-     Framework for Real-time Media Congestion Avoidance Techniques
-                      draft-zhu-rmcat-framework-00
-
-Abstract
-
-   Congestion control is an essential element in ensuring fair bandwidth
-   usage and preventing congesion collapse for traffic sharing the
-   Internet.  For interactive real-time media traffic such as video
-   conferencing, design of congestion control solution also needs to
-   account for many other factors such as the requirement for low
-   latency packet delivery and interactions with live video encoder.
-   This document describes a common framework with core functional
-   building blocks for proposed real-time media congestion solutions.
-
-Status of This Memo
-
-   This Internet-Draft is submitted in full conformance with the
-   provisions of BCP 78 and BCP 79.
-
-   Internet-Drafts are working documents of the Internet Engineering
-   Task Force (IETF).  Note that other groups may also distribute
-   working documents as Internet-Drafts.  The list of current Internet-
-   Drafts is at http://datatracker.ietf.org/drafts/current/.
-
-   Internet-Drafts are draft documents valid for a maximum of six months
-   and may be updated, replaced, or obsoleted by other documents at any
-   time.  It is inappropriate to use Internet-Drafts as reference
-   material or to cite them other than as "work in progress."
-
-   This Internet-Draft will expire on January 2, 2017.
-
-Copyright Notice
-
-   Copyright (c) 2016 IETF Trust and the persons identified as the
-   document authors.  All rights reserved.
-
-   This document is subject to BCP 78 and the IETF Trust's Legal
-   Provisions Relating to IETF Documents
-   (http://trustee.ietf.org/license-info) in effect on the date of
-   publication of this document.  Please review these documents
-   carefully, as they describe your rights and restrictions with respect
-
-
-
-Zhu & Sarker             Expires January 2, 2017                [Page 1]
-
-Internet-Draft               RMCAT framework                   July 2016
-
-
-   to this document.  Code Components extracted from this document must
-   include Simplified BSD License text as described in Section 4.e of
-   the Trust Legal Provisions and are provided without warranty as
-   described in the Simplified BSD License.
-
-Table of Contents
-
-   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
-   2.  Key Words for Requirements  . . . . . . . . . . . . . . . . .   2
-   3.  Common Terminology and Funtional Modules  . . . . . . . . . .   3
-   4.  Example Configurations  . . . . . . . . . . . . . . . . . . .   4
-     4.1.  Example Configurations for a Single Stream  . . . . . . .   4
-     4.2.  Example Configurations for Multiple Streams . . . . . . .   5
-   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   6
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   7
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .   7
-   8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   7
-     8.1.  Normative References  . . . . . . . . . . . . . . . . . .   7
-     8.2.  Informative References  . . . . . . . . . . . . . . . . .   8
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   9
-
-1.  Introduction
-
-   Given increasing amount of interactive real-time media traffic over
-   the Internet, such as video conferencing, it is important that these
-   applications employ proper congestion control mechanisms so to avoid
-   congestion collapse.  The RTP Media Congestion Avoidance Techniques
-   (RMCAT) working group was chartered to develop and standardize an
-   effective congestion control solution.  The working group document
-   [I-D.ietf-rmcat-cc-requirements] specifies the list of requirements
-   of a viable solution.
-
-   This document outlines a common framework for candidate congestion
-   control solutions currently considered by the RMCAT working group.
-   The framework contains several functionals modules that are needed
-   for properly interacting with live media/video codec and network
-   transport.
-
-2.  Key Words for Requirements
-
-   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
-   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
-   document are to be interpreted as described in [RFC2119].
-
-
-
-
-
-
-
-
-Zhu & Sarker             Expires January 2, 2017                [Page 2]
-
-Internet-Draft               RMCAT framework                   July 2016
-
-
-3.  Common Terminology and Funtional Modules
-
-   A viable solution for real-time media congestion control needs to
-   comprise of several common modules.  This section provides a brief
-   description of them and their respective functionalities.  It is
-   required that drafts on candidate RMCAT solutions follow a common set
-   of terminologies.
-
-   o  Network Congestion Controller (NCC): this is the core module for
-      estimating available bandwidth over the network based on periodic
-      RTCP feedback reports from the receiver.  Input of this module
-      include periodic RTCP feedback reports as well as shared states of
-      other flows in the same application sharing the same transport.
-      Output of this module is the estimated available bandwidth.  This
-      module contains key functions and calculations required to detect
-      congestion and estimate available bandwidth on the transport.  The
-      statistics gather via RTCP feedback reports are fed to this module
-      for such purpose.  Different RMCAT solutions employ different
-      algorithms in detecting congestion and estimating available
-      bandwidth for its media flow.  It also possible that multiple
-      media streams are multplexed over a single transport, hence share
-      the same congestion control module in aggregation.
-
-   o  Transmission Queue: this module is needed to absorb the
-      instantaneous mismatch between output from a live video encoder
-      and regulated outgoing traffic.  The Transmission Queue schedules
-      outgoing traffic according to sending rate recommended by the Rate
-      Controller.  It reports back its occupancy level to the Rate
-      Controller module to assist its future decisions on target video
-      rate, sending rate, and probing/padding rate.
-
-   o  Rate Controller: this module takes as input the estimated
-      available bandwidth from the Network Congestion Control module,
-      shared states on other flows, as well as occupancy level of the
-      Transmission Queue.  It makes holistic decisions on: a) target
-      video rate for the live video encoder; b) sending rate for
-      regulating outgoing traffic from the Transmission Queue; and c)
-      rate of FEC/padding packets when needed.  In the case where
-      multiple media streams share a single transport and a common
-      Network Congestion Controller (for estimating available bandwidth
-      in aggregation), the Rate Controller is also responsible for
-      distributing available bandwidth amongst different media streams
-      according to their relative priorities and based on Shared State
-      information.
-
-   o  FEC/Padding Packet Generator: during periods of bandwidth probing
-      or when forward error protection is needed during periods of
-      likely packet losses, additional padding or or forward error
-
-
-
-Zhu & Sarker             Expires January 2, 2017                [Page 3]
-
-Internet-Draft               RMCAT framework                   July 2016
-
-
-      correction (FEC) packets are generated by the FEC/Padding Packet
-      Generator.  While RMCAT solutions do not specify what FEC scheme
-      to use, nor how FEC or padding packets should be generated, a
-      complete congestion control solution needs tospecify total rate of
-      the FEC/Padding packets.  Decision on how the rate of FEC/padding
-      is carried out by the Rate Controller module.
-
-   o  Live Video Encoder: the sender typically also contains a live
-      video encoder, which adjusts the its encoding parameters according
-      to the target video rate set by the Rate Controller.  The output
-      rate from the Video Encoder may deviate from this target due to
-      uncertainty in the captured video content charasteristics and the
-      encoder rate control process.  Note that internal operations of
-      the Video Encoder (i.e., how video encoder rate control works) is
-      out of scope for RMCAT.  This module is should be considered as a
-      black box as part of the RMCAT solution framework.
-
-4.  Example Configurations
-
-4.1.  Example Configurations for a Single Stream
-
-
-                                                      RTCP Feedback
-   +---------+                       +-------------+   Reports
-   |  Live   |                       |   Network   |<----------------
-   |  Video  |<----------------+     |  Congestion |
-   | Encoder |                 |     |  Controller |<------+
-   +---------+                 |     +-------------+       |  Shared
-       ||                      |            |(1)           |  States
-       ||                      |            |              +----------
-       ||                      |           \|/             |
-       ||    +--------------+  |  (4) +-------------+      |
-       ||    | FEC/Padding  |  +------|    Rate     |<-----+
-       ||    |  Packet      |<--------| Controller  |
-       ||    | Generator    |    (5)  +-------------+
-       ||    +--------------+          (3)|   /|\
-       ||           ||                    |    |
-       ||           || FEC/Padding       \|/   |(2)
-       ||           || Packets       +---------------+
-       ||           \\=============> |  Transmission |
-       \\==========================> |      Queue    |==============>
-           Encoded Video Packets     +---------------+   Outgoing
-                                                          Packets
-
-
-      Figure 1: RMCAT Solution Framework at the Sender: Single Stream
-
-
-
-
-
-Zhu & Sarker             Expires January 2, 2017                [Page 4]
-
-Internet-Draft               RMCAT framework                   July 2016
-
-
-   Figure 1 shows an example configuration at the sender for supporting
-   a single media stream.  The Network Congestion Controller (NCC)
-   calculates estimated available bandwidth (1) based on periodic RTCP
-   feedback reports and shared states about other streams.  The Rate
-   Controller takes as input the estimated available bandwidth (1), the
-   current occupancy level of the Transmission Queue (2), as well as the
-   shared states on other flows, and calculates sending rate (3) for the
-   Transmission Queue, video target rate (4) as input to the live video
-   encoder, and rate of FEC/Padding packets (5) if they are needed.  The
-   Transmission Queue holds output packets from both the Live Video
-   Encoder and the FEC/Padding packet generator, and regulates its
-   outgoing traffic according to the sending rate (3) specified by Rate
-   Controller.
-
-   Obviously, it is possible for a candidate RMCAT solution to contain
-   alternative configurations (wirings) between the functional modules,
-   as well as alterantive implementations of each function module.  It
-   is required that the candidate solution draft specify how they align
-   to this framework.
-
-4.2.  Example Configurations for Multiple Streams
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Zhu & Sarker             Expires January 2, 2017                [Page 5]
-
-Internet-Draft               RMCAT framework                   July 2016
-
-
-        +--------------------------+    +---------------------------+
-        |       Video encoder      |    |        Video encoder      |
-        +--------------------------+    +---------------------------+
-            /|\           ||                 /|\         ||
-          (4)|            ||               (4)|       (2)||
-             |           \||/                 |         \||/
-                    +-------------+                +--------------+
-                (3) |Transmission |(2)         (3) | Transmission |(2)
-              ----->|   Queue     |--->       ---->|    Queue     |--->
-                    +-------------+                +--------------+
-                          ||                             ||
-                         \||/                           \||/
-
-
-           +------------+      +------------+
-           |  Network   | (1)  |    Rate    |--> (3)
-           | Congestion |----->| Controller |--> (4)
-           | Controller |      |            |--> (5)
-           --------------      +------------+
-              /|\    /|\           /|\
-      RTCP     |      |             |
-      Feedback |      +------+-----+
-      Reports  |             | Shared
-               |             | States
-
-
-    Figure 2: RMCAT Solution Framework at the Sender: Multiple Streams
-
-   Figure 2 shows an example configuration for multiple video streams
-   sharing a common Network Congestion Controller (NCC).  The NCC
-   calculates an aggregated estimated available bandwidth (1) based on
-   periodic RTCP feedback reports and Shared States (?).  Based on such
-   information and occupancy level of the transmission queue for each
-   substream (2), the Rate Controller divides up the aggregate estimated
-   bandwidth amongst sub-streams based on their relative priority
-   levels, and subsequently regulates the sending rate of each
-   Transmission Queue (3), target video rate (4), and FEC/padding rate
-   (5) for each sub-stream.  For sake of abrevity the role of FEC/
-   padding packet generators are omitted in the above figure.
-
-5.  Acknowledgements
-
-   The RMCAT design team discussions contributed to this memo.
-
-
-
-
-
-
-
-
-Zhu & Sarker             Expires January 2, 2017                [Page 6]
-
-Internet-Draft               RMCAT framework                   July 2016
-
-
-6.  IANA Considerations
-
-   This memo includes no request to IANA.
-
-7.  Security Considerations
-
-   TBD
-
-8.  References
-
-8.1.  Normative References
-
-   [I-D.ietf-avtcore-rtp-circuit-breakers]
-              Perkins, C. and V. Singh, "Multimedia Congestion Control:
-              Circuit Breakers for Unicast RTP Sessions", draft-ietf-
-              avtcore-rtp-circuit-breakers-05 (work in progress),
-              February 2014.
-
-   [I-D.ietf-rmcat-cc-requirements]
-              Jesup, R., "Congestion Control Requirements For RMCAT",
-              draft-ietf-rmcat-cc-requirements-04 (work in progress),
-              April 2014.
-
-   [I-D.ietf-rmcat-eval-criteria]
-              Singh, V. and J. Ott, "Evaluating Congestion Control for
-              Interactive Real-time Media", draft-ietf-rmcat-eval-
-              criteria-01 (work in progress), March 2014.
-
-   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
-              Requirement Levels", BCP 14, RFC 2119, March 1997.
-
-   [RFC3550]  Schulzrinne, H., Casner, S., Frederick, R., and V.
-              Jacobson, "RTP: A Transport Protocol for Real-Time
-              Applications", STD 64, RFC 3550, July 2003.
-
-   [RFC3551]  Schulzrinne, H. and S. Casner, "RTP Profile for Audio and
-              Video Conferences with Minimal Control", STD 65, RFC 3551,
-              July 2003.
-
-   [RFC4566]  Handley, M., Jacobson, V., and C. Perkins, "SDP: Session
-              Description Protocol", RFC 4566, DOI 10.17487/RFC4566,
-              July 2006, <http://www.rfc-editor.org/info/rfc4566>.
-
-   [RFC4585]  Ott, J., Wenger, S., Sato, N., Burmeister, C., and J. Rey,
-              "Extended RTP Profile for Real-time Transport Control
-              Protocol (RTCP)-Based Feedback (RTP/AVPF)", RFC 4585, July
-              2006.
-
-
-
-
-Zhu & Sarker             Expires January 2, 2017                [Page 7]
-
-Internet-Draft               RMCAT framework                   July 2016
-
-
-   [RFC5104]  Wenger, S., Chandra, U., Westerlund, M., and B. Burman,
-              "Codec Control Messages in the RTP Audio-Visual Profile
-              with Feedback (AVPF)", RFC 5104, DOI 10.17487/RFC5104,
-              February 2008, <http://www.rfc-editor.org/info/rfc5104>.
-
-   [RFC5450]  Singer, D. and H. Desineni, "Transmission Time Offsets in
-              RTP Streams", RFC 5450, DOI 10.17487/RFC5450, March 2009,
-              <http://www.rfc-editor.org/info/rfc5450>.
-
-   [RFC5506]  Johansson, I. and M. Westerlund, "Support for Reduced-Size
-              Real-Time Transport Control Protocol (RTCP): Opportunities
-              and Consequences", RFC 5506, April 2009.
-
-   [RFC5761]  Perkins, C. and M. Westerlund, "Multiplexing RTP Data and
-              Control Packets on a Single Port", RFC 5761, DOI 10.17487/
-              RFC5761, April 2010,
-              <http://www.rfc-editor.org/info/rfc5761>.
-
-8.2.  Informative References
-
-   [RFC0768]  Postel, J., "User Datagram Protocol", STD 6, RFC 768, DOI
-              10.17487/RFC0768, August 1980,
-              <http://www.rfc-editor.org/info/rfc768>.
-
-   [RFC4340]  Kohler, E., Handley, M., and S. Floyd, "Datagram
-              Congestion Control Protocol (DCCP)", RFC 4340, DOI 10
-              .17487/RFC4340, March 2006,
-              <http://www.rfc-editor.org/info/rfc4340>.
-
-   [RFC5109]  Li, A., Ed., "RTP Payload Format for Generic Forward Error
-              Correction", RFC 5109, DOI 10.17487/RFC5109, December
-              2007, <http://www.rfc-editor.org/info/rfc5109>.
-
-   [RFC5348]  Floyd, S., Handley, M., Padhye, J., and J. Widmer, "TCP
-              Friendly Rate Control (TFRC): Protocol Specification", RFC
-              5348, DOI 10.17487/RFC5348, September 2008,
-              <http://www.rfc-editor.org/info/rfc5348>.
-
-   [RFC5681]  Allman, M., Paxson, V., and E. Blanton, "TCP Congestion
-              Control", RFC 5681, September 2009.
-
-   [RFC6330]  Luby, M., Shokrollahi, A., Watson, M., Stockhammer, T.,
-              and L. Minder, "RaptorQ Forward Error Correction Scheme
-              for Object Delivery", RFC 6330, DOI 10.17487/RFC6330,
-              August 2011, <http://www.rfc-editor.org/info/rfc6330>.
-
-
-
-
-
-
-Zhu & Sarker             Expires January 2, 2017                [Page 8]
-
-Internet-Draft               RMCAT framework                   July 2016
-
-
-   [RFC6865]  Roca, V., Cunche, M., Lacan, J., Bouabdallah, A., and K.
-              Matsuzono, "Simple Reed-Solomon Forward Error Correction
-              (FEC) Scheme for FECFRAME", RFC 6865, DOI 10.17487/
-              RFC6865, February 2013,
-              <http://www.rfc-editor.org/info/rfc6865>.
-
-Authors' Addresses
-
-   Xianqing Zhu
-   Cisco Systems
-   12515 Research Blvd., Building 4
-   Austin, TX  78759
-   USA
-
-   Email: xiaoqzhu@cisco.com
-
-
-   Zaheduzzaman Sarker
-   Ericsson AB
-   Luleae
-   Sweden
-
-   Email: zaheduzzaman.sarker@ericsson.com
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Zhu & Sarker             Expires January 2, 2017                [Page 9]
+
+
+
+RMCAT WG                                                          X. Zhu
+Internet-Draft                                             Cisco Systems
+Intended status: Informational                                 Z. Sarker
+Expires: January 01, 2017                                    Ericsson AB
+                                                           July 02, 2016
+
+     Framework for Real-time Media Congestion Avoidance Techniques
+                      draft-zhu-rmcat-framework-00
+
+Abstract
+
+   Congestion control is an essential element in ensuring fair bandwidth
+   usage and preventing congestion collapse for traffic sharing the
+   Internet.  For interactive real-time media traffic such as video
+   conferencing, design of congestion control solution also needs to
+   account for many other factors such as the requirement for low
+   latency packet delivery and interactions with live video encoder.
+   This document describes a common framework with the core functional
+   building blocks for a real-time media congestion solutions.
+
+Status of this Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at http://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on January 01, 2017.
+
+Copyright Notice
+
+   Copyright (c) 2016 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents (http://trustee.ietf.org/
+   license-info) in effect on the date of publication of this document.
+
+
+
+
+
+
+
+
+Zhu & Sarker            Expires January 01, 2017                [Page 1]
+
+Internet-Draft              RMCAT framework                    July 2016
+
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.  Code Components
+   extracted from this document must include Simplified BSD License text
+   as described in Section 4.e of the Trust Legal Provisions and are
+   provided without warranty as described in the Simplified BSD License.
+
+Table of Contents
+
+   1.  Introduction . . . . . . . . . . . . . . . . . . . . . . . . .  2
+   2.  Key Words for Requirements . . . . . . . . . . . . . . . . . .  2
+   3.  Functional Modules . . . . . . . . . . . . . . . . . . . . . .  2
+   4.  Example Configurations . . . . . . . . . . . . . . . . . . . .  4
+     4.1.  Example Configurations for a Single Stream . . . . . . . .  4
+     4.2.  Example Configurations for Multiple Streams  . . . . . . .  5
+   5.  Acknowledgements . . . . . . . . . . . . . . . . . . . . . . .  5
+   6.  IANA Considerations  . . . . . . . . . . . . . . . . . . . . .  5
+   7.  Security Considerations  . . . . . . . . . . . . . . . . . . .  5
+   8.  References . . . . . . . . . . . . . . . . . . . . . . . . . .  6
+     8.1.  Normative References . . . . . . . . . . . . . . . . . . .  6
+     8.2.  Informative References . . . . . . . . . . . . . . . . . .  6
+   Authors' Addresses . . . . . . . . . . . . . . . . . . . . . . . .  6
+
+1.  Introduction
+
+   Given increasing amount of interactive real-time media traffic over
+   the Internet, such as video conferencing, it is important that these
+   applications employ proper congestion control mechanisms to avoid
+   congestion collapse.  [I-D.ietf-rmcat-cc-requirements] specifies the
+   list of requirements of a viable solution.
+
+   This document outlines a common framework for designing a congestion
+   control mechanism for real-time interactive communication.  [
+   Editor's note : This document does not describe the interaction
+   between application , codec and congestion control system.  The
+   interaction among application, codec and congestion control system
+   are define in other documents.  There is a possibility to merge all
+   the documents into one single document.  ]
+
+2.  Key Words for Requirements
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+3.  Functional Modules
+
+   A viable solution for real-time media congestion control needs to
+   comprise of several common modules.  This section provides a brief
+   description of them and their respective functionalities.  A
+   congestion control solution for real-time media should comprise of
+
+
+
+
+
+Zhu & Sarker            Expires January 01, 2017                [Page 2]
+
+Internet-Draft              RMCAT framework                    July 2016
+
+   the described functional modules.  This should help understanding
+   different congestion control solutions.
+
+   o  Network Congestion Controller : this is the core module for
+      estimating available bandwidth over the network based on periodic
+      RTCP feedback reports [RFC3550] from the receiver.  Input of this
+      module include periodic RTCP feedback reports as well as shared
+      states of other flows in the same application sharing the same
+      transport bottleneck.  Output of this module is the estimated
+      available bandwidth.  This module contains key functions and
+      calculations required to detect congestion and estimate available
+      bandwidth on the transmission path based on the receiption quality
+      of the media traffic.  Different congestion control solutions
+      employ different algorithms in detecting congestion and estimating
+      available bandwidth for its media flow.  It also possible that
+      multiple media streams are multiplexed over a single transport,
+      hence share the same congestion control module in aggregation.
+
+   o  Transmission Queue : this module is needed to absorb the
+      instantaneous mismatch between output from a live video encoder
+      and regulated outgoing traffic.  The transmission queue schedules
+      outgoing traffic according to sending rate recommended by a rate
+      controller module.  It reports back its occupancy level to the
+      rate controller module to assist the future rate control decisions
+      on target video rate, sending rate, and probing rate.
+
+   o  Rate Controller : this module takes the estimated available
+      bandwidth from the network congestion control module, shared
+      states of other flows, as well as occupancy level of the
+      transmission queue as input.  It makes holistic decisions on: a)
+      target video rate for the live video encoder; b) sending rate for
+      regulating outgoing traffic for the transmission queue; and c)
+      rate of probing packets when needed.  In the case where multiple
+      media streams share a single transport and a common network
+      congestion controller (for estimating available bandwidth in
+      aggregation), the controller is also responsible for distributing
+      available bandwidth amongst different media streams according to
+      their relative priorities and based on shared state information.
+
+   o  Network Probe : A congestion control solution can use probing to
+      estimate the available bandwidth on the media transmission path.
+      This can be specially effective when increasing the transmission
+      rate.  The solution can use different techniques for probing the
+      network - for example it can use simple dummy packet with unknown
+      payload type or use Forward Error Correction (FEC) packets.  The
+      network probe module is responsible for such packet generation.
+      While this document does not specify what probing technique to use
+      or how those packets should be generated, a complete congestion
+      control solution needs to specify total rate of the probe packets
+      to the rate controller module.
+
+
+
+
+
+Zhu & Sarker            Expires January 01, 2017                [Page 3]
+
+Internet-Draft              RMCAT framework                    July 2016
+
+
+   o  Live Video Encoder : the sender typically also contains a live
+      video encoder, which adjusts the its encoding parameters according
+      to the target video rate set by the rate controller.  The output
+      rate from the video encoder may deviate from this target due to
+      uncertainty in the captured video content characteristics and the
+      encoder rate control process.  Note that internal operations of
+      the video encoder (i.e., how video encoder rate control works) is
+      out of scope for this document.
+
+4.  Example Configurations
+
+4.1.  Example Configurations for a Single Stream
+
+   
+                                                      RTCP Feedback
+   +---------+                       +-------------+   Reports
+   |  Live   |                       |   Network   |<----------------
+   |  Video  |<----------------+     |  Congestion |
+   | Encoder |                 |     |  Controller |<------+
+   +---------+                 |     +-------------+       |  Shared
+       ||                      |            |(1)           |  States
+       ||                      |            |              +----------
+       ||                      |           \|/             |
+       ||    +--------------+  |  (4) +-------------+      |
+       ||    |   Network    |  +------|    Rate     |<-----+
+       ||    |    probe     |<--------| Controller  |
+       ||    |              |    (5)  +-------------+
+       ||    +--------------+          (3)|   /|\
+       ||           ||                    |    |
+       ||           || FEC/Padding       \|/   |(2)
+       ||           || Packets       +---------------+
+       ||           \\=============> |  Transmission |
+       \\==========================> |      Queue    |==============>
+           Encoded Video Packets     +---------------+   Outgoing
+                                                          Packets
+   
+
+   Figure 1 shows an example configuration at the sender for supporting
+   a single media stream.  The Network Congestion Controller estimates
+   available bandwidth based on periodic RTCP feedback reports and
+   shared states about other streams.  The Rate Controller takes the
+   estimated available bandwidth (1) , the current occupancy level of
+   the Transmission Queue (2), as well as the shared states on other
+   flows as inputs and calculates sending rate (3) for the Transmission
+   Queue.  It then distributes the sending rate between the live video
+   encoder as target encoding rate (4), and rate of probe packets (5) if
+   they are needed.  The Transmission Queue holds output packets from
+   both the Live Video Encoder and the Network Probe, and regulates its
+   outgoing traffic according to the sending rate (3) specified by Rate
+   Controller.
+
+
+
+
+Zhu & Sarker            Expires January 01, 2017                [Page 4]
+
+Internet-Draft              RMCAT framework                    July 2016
+
+
+   Obviously, it is possible for a congestion control solution to
+   contain alternative configurations (wirings) between the functional
+   modules.  It is required that the candidate solution draft specify
+   how they align to this framework.
+
+4.2.  Example Configurations for Multiple Streams
+
+   
+                                                      RTCP Feedback
+   +---------+                       +-------------+   Reports
+   |  Live   |                       |   Network   |<----------------
+   |  Video  |<----------------+     |  Congestion |
+   | Encoder |                 |     |  Controller |<------+
+   +---------+                 |     +-------------+       |  Shared
+       ||                      |            |(1)           |  States
+       ||                      |            |              +----------
+       ||                      |           \|/             |
+       ||                      |  (4) +-------------+      |
+       ||      +---------+     +------|    Rate     |<-----+
+       ||      |  Live   |     |      | Controller  |
+       ||      |  Video  |<----+      +-------------+
+       ||      | Encoder |             (3)|   /|\
+       ||      +---------+                |    |
+       ||          ||                    \|/   |(2)
+       ||          ||                +---------------+
+       ||          ||                |  Transmission |
+       \\==========================> |      Queue    |==============>
+           Encoded Video Packets     +---------------+   Outgoing
+                                                          Packets
+   
+
+   Figure 2 shows an example configuration for multiple video streams
+   sharing a common Network Congestion Controller.  The Network
+   Congestion Controller calculates an aggregated estimated available
+   bandwidth (1) based on periodic RTCP feedback reports and Shared
+   States.  Based on such information and occupancy level of the
+   transmission queue for each sub stream (2), the Rate Controller
+   divides up the aggregate estimated bandwidth amongst sub-streams
+   based on their relative priority levels, and subsequently regulates
+   the sending rate of each Transmission Queue (3), target video rate
+   (4). For sake of simplicity the role of network probe is omitted in
+   the above figure.
+
+5.  Acknowledgements
+
+   The RMCAT design team discussions contributed to this memo.
+
+6.  IANA Considerations
+
+   This memo includes no request to IANA.
+
+7.  Security Considerations
+
+
+Zhu & Sarker            Expires January 01, 2017                [Page 5]
+
+Internet-Draft              RMCAT framework                    July 2016
+
+
+   TBD
+
+8.  References
+
+8.1.  Normative References
+
+   [I-D.ietf-rmcat-cc-requirements]
+              Jesup, R., "Congestion Control Requirements For RMCAT",
+              Internet-Draft draft-ietf-rmcat-cc-requirements-04, April
+              2014.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC3550]  Schulzrinne, H., Casner, S., Frederick, R. and V.
+              Jacobson, "RTP: A Transport Protocol for Real-Time
+              Applications", STD 64, RFC 3550, July 2003.
+
+   [RFC3551]  Schulzrinne, H. and S. Casner, "RTP Profile for Audio and
+              Video Conferences with Minimal Control", STD 65, RFC 3551,
+              July 2003.
+
+   [RFC4585]  Ott, J., Wenger, S., Sato, N., Burmeister, C. and J. Rey,
+              "Extended RTP Profile for Real-time Transport Control
+              Protocol (RTCP)-Based Feedback (RTP/AVPF)", RFC 4585, July
+              2006.
+
+   [RFC5104]  Wenger, S., Chandra, U., Westerlund, M. and B. Burman,
+              "Codec Control Messages in the RTP Audio-Visual Profile
+              with Feedback (AVPF)", RFC 5104, February 2008.
+
+8.2.  Informative References
+
+   [RFC0768]  Postel, J., "User Datagram Protocol", STD 6, RFC 768,
+              August 1980.
+
+Authors' Addresses
+
+   Xianqing Zhu
+   Cisco Systems
+   12515 Research Blvd., Building 4
+   Austin, TX 78759
+   USA
+   
+   Email: xiaoqzhu@cisco.com
+
+
+
+
+
+
+
+
+
+Zhu & Sarker            Expires January 01, 2017                [Page 6]
+
+Internet-Draft              RMCAT framework                    July 2016
+
+
+   Zaheduzzaman Sarker
+   Ericsson AB
+   Luleae,
+   Sweden
+   
+   Phone: 00 46 10 717 37 43
+   Email: zaheduzzaman.sarker@ericsson.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Zhu & Sarker            Expires January 01, 2017                [Page 7]

--- a/draft-zhu-rmcat-framework.xml
+++ b/draft-zhu-rmcat-framework.xml
@@ -21,8 +21,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-zhu-rmcat-framework-00"
-     ipr="trust200902">
+<rfc category="info" docName="draft-zhu-rmcat-framework-00" ipr="trust200902">
   <!-- category values: std, bcp, info, exp, and historic
      ipr values: full3667, noModification3667, noDerivatives3667
      you can add the attributes updates="NNNN" and obsoletes="NNNN" 
@@ -38,15 +37,20 @@
     <!-- add 'role="editor"' below for the editors if appropriate -->
 
     <!-- Another author who claims to be an editor -->
+
     <author fullname="Xianqing Zhu" initials="X" surname="Zhu">
       <organization>Cisco Systems</organization>
 
       <address>
         <postal>
           <street>12515 Research Blvd., Building 4</street>
+
           <city>Austin</city>
+
           <region>TX</region>
+
           <code>78759</code>
+
           <country>USA</country>
         </postal>
 
@@ -54,12 +58,11 @@
 
         <facsimile></facsimile>
 
-        <email>xiaoqzhu@cisco.com </email>
+        <email>xiaoqzhu@cisco.com</email>
 
         <uri></uri>
       </address>
     </author>
-
 
     <author fullname="Zaheduzzaman Sarker" initials="Z." surname="Sarker">
       <organization>Ericsson AB</organization>
@@ -77,13 +80,13 @@
           <country>Sweden</country>
         </postal>
 
-        <phone></phone>
+        <phone>00 46 10 717 37 43</phone>
 
         <email>zaheduzzaman.sarker@ericsson.com</email>
       </address>
     </author>
 
-    <date day="" month="" year="2016" />
+    <date day="02" month="July" year="2016" />
 
     <!-- If the month and year are both specified and are the current ones, xml2rfc will fill
      in the current day for you. If only the current year is specified, xml2rfc will fill
@@ -94,7 +97,7 @@
 
     <!-- Meta-data Declarations -->
 
-    <area>RAI</area>
+    <area>Transport</area>
 
     <workgroup>RMCAT WG</workgroup>
 
@@ -111,41 +114,33 @@
      keywords will be used for the search engine. -->
 
     <abstract>
-
-    <t>Congestion control is an essential element in ensuring fair bandwidth
-       usage and preventing congesion collapse for traffic sharing the Internet.
-       For interactive real-time media traffic such as video conferencing,
-       design of congestion control solution also needs to account for
-       many other factors such as the requirement for low latency packet delivery
-       and interactions with live video encoder. 
-
-       This document describes a common framework with core functional
-       building blocks for proposed real-time media congestion solutions.
-     </t>
-
+      <t>Congestion control is an essential element in ensuring fair bandwidth
+      usage and preventing congestion collapse for traffic sharing the
+      Internet. For interactive real-time media traffic such as video
+      conferencing, design of congestion control solution also needs to
+      account for many other factors such as the requirement for low latency
+      packet delivery and interactions with live video encoder. This document
+      describes a common framework with the core functional building blocks
+      for a real-time media congestion solutions.</t>
     </abstract>
   </front>
 
   <middle>
     <section title="Introduction">
+      <t>Given increasing amount of interactive real-time media traffic over
+      the Internet, such as video conferencing, it is important that these
+      applications employ proper congestion control mechanisms to avoid
+      congestion collapse. <xref
+      target="I-D.ietf-rmcat-cc-requirements"></xref> specifies the list of
+      requirements of a viable solution.</t>
 
-    <t>Given increasing amount of interactive real-time media traffic
-       over the Internet, such as video conferencing, it is important
-       that these applications employ proper congestion control
-       mechanisms so to avoid congestion collapse. The RTP Media
-       Congestion Avoidance Techniques (RMCAT) working group was
-       chartered to develop and standardize an effective congestion
-       control solution. The working group document 
-       <xref target="I-D.ietf-rmcat-cc-requirements"></xref>
-       specifies the list of requirements of a viable solution.</t>
-
-    <t>This document outlines a common framework for candidate
-       congestion control solutions currently considered by
-       the RMCAT working group. The framework contains several
-       functionals modules that are needed for properly
-       interacting with live media/video codec and network
-       transport.</t>
-
+      <t>This document outlines a common framework for designing a congestion
+      control mechanism for real-time interactive communication. [ Editor's
+      note : This document does not describe the interaction between
+      application , codec and congestion control system. The interaction among
+      application, codec and congestion control system are define in other
+      documents. There is a possibility to merge all the documents into one
+      single document. ]</t>
     </section>
 
     <section title="Key Words for Requirements">
@@ -155,104 +150,81 @@
       target="RFC2119"></xref>.</t>
     </section>
 
-    <section title="Common Terminology and Funtional Modules">
-   
-<t>A viable solution for real-time media congestion control needs
-to comprise of several common modules. This section provides 
-a brief description of them and their respective functionalities. 
-It is required that drafts on candidate RMCAT solutions follow
-a common set of terminologies. </t> 
+    <section title="Functional Modules">
+      <t>A viable solution for real-time media congestion control needs to
+      comprise of several common modules. This section provides a brief
+      description of them and their respective functionalities. A congestion
+      control solution for real-time media should comprise of the described
+      functional modules. This should help understanding different congestion
+      control solutions.</t>
 
-<t><list style="symbols">
+      <t><list style="symbols">
+          <t>Network Congestion Controller : this is the core module for
+          estimating available bandwidth over the network based on periodic
+          RTCP feedback reports <xref target="RFC3550"></xref> from the
+          receiver. Input of this module include periodic RTCP feedback
+          reports as well as shared states of other flows in the same
+          application sharing the same transport bottleneck. Output of this
+          module is the estimated available bandwidth. This module contains
+          key functions and calculations required to detect congestion and
+          estimate available bandwidth on the transmission path based on the
+          receiption quality of the media traffic. Different congestion
+          control solutions employ different algorithms in detecting
+          congestion and estimating available bandwidth for its media flow. It
+          also possible that multiple media streams are multiplexed over a
+          single transport, hence share the same congestion control module in
+          aggregation.</t>
 
-<t>Network Congestion Controller (NCC): this is the
-core module for estimating available bandwidth over
-the network based on periodic RTCP feedback reports from 
-the receiver. Input of this module include periodic RTCP
-feedback reports as well as shared states of other flows
-in the same application sharing the same transport.
-Output of this module is the estimated available 
-bandwidth. This module contains key functions and
-calculations required to detect congestion and estimate
-available bandwidth on the transport. The statistics gather
-via RTCP feedback reports are fed to this module for such
-purpose. Different RMCAT solutions employ different
-algorithms in detecting congestion and estimating
-available bandwidth for its media flow. It also
-possible that multiple media streams are multplexed
-over a single transport, hence share the same congestion
-control module in aggregation. 
-</t>
+          <t>Transmission Queue : this module is needed to absorb the
+          instantaneous mismatch between output from a live video encoder and
+          regulated outgoing traffic. The transmission queue schedules
+          outgoing traffic according to sending rate recommended by a rate
+          controller module. It reports back its occupancy level to the rate
+          controller module to assist the future rate control decisions on
+          target video rate, sending rate, and probing rate.</t>
 
-<t>Transmission Queue: this module is needed
-to absorb the instantaneous mismatch between
-output from a live video encoder and regulated
-outgoing traffic. The Transmission Queue schedules
-outgoing traffic according to sending rate
-recommended by the Rate Controller. It reports
-back its occupancy level to the Rate Controller
-module to assist its future decisions on target
-video rate, sending rate, and probing/padding
-rate. 
-</t>
+          <t>Rate Controller : this module takes the estimated available
+          bandwidth from the network congestion control module, shared states
+          of other flows, as well as occupancy level of the transmission queue
+          as input. It makes holistic decisions on: a) target video rate for
+          the live video encoder; b) sending rate for regulating outgoing
+          traffic for the transmission queue; and c) rate of probing packets
+          when needed. In the case where multiple media streams share a single
+          transport and a common network congestion controller (for estimating
+          available bandwidth in aggregation), the controller is also
+          responsible for distributing available bandwidth amongst different
+          media streams according to their relative priorities and based on
+          shared state information.</t>
 
-<t>Rate Controller: this module takes as input
-the estimated available bandwidth from the 
-Network Congestion Control module, shared states
-on other flows, as well as occupancy level of
-the Transmission Queue. It makes holistic decisions
-on: a) target video rate for the live video
-encoder; b) sending rate for regulating outgoing
-traffic from the Transmission Queue; and c) 
-rate of FEC/padding packets when needed. 
-In the case where multiple media streams
-share a single transport and a common Network
-Congestion Controller (for estimating available
-bandwidth in aggregation), the Rate Controller
-is also responsible for distributing available
-bandwidth amongst different media streams according
-to their relative priorities and based on
-Shared State information.</t>
+          <t>Network Probe : A congestion control solution can use probing to
+          estimate the available bandwidth on the media transmission path.
+          This can be specially effective when increasing the transmission
+          rate. The solution can use different techniques for probing the
+          network - for example it can use simple dummy packet with unknown
+          payload type or use Forward Error Correction (FEC) packets. The
+          network probe module is responsible for such packet generation.
+          While this document does not specify what probing technique to use
+          or how those packets should be generated, a complete congestion
+          control solution needs to specify total rate of the probe packets to
+          the rate controller module.</t>
 
-<t>FEC/Padding Packet Generator: during periods of
-bandwidth probing or when forward error protection is
-needed during periods of likely packet losses, 
-additional padding or or forward error correction (FEC)
-packets are generated by the FEC/Padding Packet Generator.
-While RMCAT solutions do not specify what FEC scheme to
-use, nor how FEC or padding packets should be generated,
-a complete congestion control solution needs tospecify
-total rate of the FEC/Padding packets. Decision on how
-the rate of FEC/padding is carried out by the Rate Controller
-module. </t>
+          <t>Live Video Encoder : the sender typically also contains a live
+          video encoder, which adjusts the its encoding parameters according
+          to the target video rate set by the rate controller. The output rate
+          from the video encoder may deviate from this target due to
+          uncertainty in the captured video content characteristics and the
+          encoder rate control process. Note that internal operations of the
+          video encoder (i.e., how video encoder rate control works) is out of
+          scope for this document. </t>
+        </list></t>
+    </section>
 
-<t>
-Live Video Encoder: the sender typically also contains a live
-video encoder, which adjusts the its encoding parameters
-according to the target video rate set by the Rate Controller.
-The output rate from the Video Encoder may deviate from this
-target due to uncertainty in the captured video content charasteristics
-and the encoder rate control process. Note that internal 
-operations of the Video Encoder (i.e., how video encoder rate
-control works) is out of scope for RMCAT. This module is
-should be considered as a black box as part of the RMCAT solution
-framework. 
-</t>
-
-</list></t>
-
-</section>
-
-<section title = "Example Configurations">
-
-
-<section title = "Example Configurations for a Single Stream"
-	 anchor = "subsec-config-single-stream">
-
+    <section title="Example Configurations">
+      <section anchor="subsec-config-single-stream"
+               title="Example Configurations for a Single Stream">
         <t><figure anchor="fig-rmcat-solution-framework"
-                   title="RMCAT Solution Framework at the Sender: Single Stream">
-     
-<artwork><![CDATA[
+            title="RMCAT Solution Framework at the Sender: Single Stream">
+            <artwork><![CDATA[
 
                                                    RTCP Feedback
 +---------+                       +-------------+   Reports
@@ -264,9 +236,9 @@ framework.
     ||                      |            |              +----------  
     ||                      |           \|/             |
     ||    +--------------+  |  (4) +-------------+      |
-    ||    | FEC/Padding  |  +------|    Rate     |<-----+    
-    ||    |  Packet      |<--------| Controller  | 
-    ||    | Generator    |    (5)  +-------------+
+    ||    |   Network    |  +------|    Rate     |<-----+    
+    ||    |    probe     |<--------| Controller  | 
+    ||    |              |    (5)  +-------------+
     ||    +--------------+          (3)|   /|\ 
     ||           ||                    |    |
     ||           || FEC/Padding       \|/   |(2)         
@@ -276,86 +248,73 @@ framework.
         Encoded Video Packets     +---------------+   Outgoing  
                                                        Packets     
                 
-]]></artwork></figure></t>
+]]></artwork>
+          </figure></t>
 
-<t><xref target="fig-rmcat-solution-framework"></xref> 
-shows an example configuration at the sender for 
-supporting a single media stream. The Network Congestion
-Controller (NCC) calculates estimated available
-bandwidth (1) based on periodic RTCP feedback reports
-and shared states about other streams.  The Rate Controller
-takes as input the estimated available bandwidth (1), 
-the current occupancy level of the Transmission Queue (2), 
-as well as the shared states on other flows, and calculates
-sending rate (3) for the Transmission Queue, video target
-rate (4) as input to the live video encoder, and rate of
-FEC/Padding packets (5) if they are needed. The Transmission
-Queue holds output packets from both the Live Video Encoder
-and the FEC/Padding packet generator, and regulates
-its outgoing traffic according to the sending rate (3)
-specified by Rate Controller. </t>
+        <t><xref target="fig-rmcat-solution-framework"></xref> shows an
+        example configuration at the sender for supporting a single media
+        stream. The Network Congestion Controller estimates available
+        bandwidth based on periodic RTCP feedback reports and shared states
+        about other streams. The Rate Controller takes the estimated available
+        bandwidth (1) , the current occupancy level of the Transmission Queue
+        (2), as well as the shared states on other flows as inputs and
+        calculates sending rate (3) for the Transmission Queue. It then
+        distributes the sending rate between the live video encoder as target
+        encoding rate (4), and rate of probe packets (5) if they are needed.
+        The Transmission Queue holds output packets from both the Live Video
+        Encoder and the Network Probe, and regulates its outgoing traffic
+        according to the sending rate (3) specified by Rate Controller.</t>
 
-<t>Obviously, it is possible for a candidate RMCAT 
-solution to contain alternative configurations (wirings)
-between the functional modules, as well as alterantive
-implementations of each function module. It is required
-that the candidate solution draft specify how they align
-to this framework. </t>
+        <t>Obviously, it is possible for a congestion control solution to
+        contain alternative configurations (wirings) between the functional
+        modules. It is required that the candidate solution draft specify how
+        they align to this framework.</t>
+      </section>
 
-</section>
+      <section anchor="subsec-config-multiple-streams"
+               title="Example Configurations for Multiple Streams">
+        <t><figure anchor="fig-rmcat-solution-multi-stream"
+            title="RMCAT Solution Framework at the Sender: Multiple Streams">
+            <artwork><![CDATA[  
 
-
-<section title = "Example Configurations for Multiple Streams"
-	 anchor = "subsec-config-multiple-streams">
-
-      <t><figure anchor = "fig-rmcat-solution-multi-stream"
-		 title = "RMCAT Solution Framework at the Sender: Multiple Streams">
-          <artwork><![CDATA[  
-
-     +--------------------------+    +---------------------------+
-     |       Video encoder      |    |        Video encoder      |
-     +--------------------------+    +---------------------------+
-         /|\           ||                 /|\         ||       
-       (4)|            ||               (4)|       (2)||
-          |           \||/                 |         \||/ 
-                 +-------------+                +--------------+
-             (3) |Transmission |(2)         (3) | Transmission |(2)
-           ----->|   Queue     |--->       ---->|    Queue     |--->
-                 +-------------+                +--------------+
-                       ||                             ||
-                      \||/                           \||/
-
-
-        +------------+      +------------+
-        |  Network   | (1)  |    Rate    |--> (3)
-        | Congestion |----->| Controller |--> (4)
-        | Controller |      |            |--> (5)
-        --------------      +------------+
-           /|\    /|\           /|\
-   RTCP     |      |             |
-   Feedback |      +------+-----+ 
-   Reports  |             | Shared
-            |             | States
+                                                   RTCP Feedback
++---------+                       +-------------+   Reports
+|  Live   |                       |   Network   |<---------------- 
+|  Video  |<----------------+     |  Congestion |
+| Encoder |                 |     |  Controller |<------+
++---------+                 |     +-------------+       |  Shared
+    ||                      |            |(1)           |  States
+    ||                      |            |              +----------  
+    ||                      |           \|/             |
+    ||                      |  (4) +-------------+      |
+    ||      +---------+     +------|    Rate     |<-----+    
+    ||      |  Live   |     |      | Controller  | 
+    ||      |  Video  |<----+      +-------------+
+    ||      | Encoder |             (3)|   /|\ 
+    ||      +---------+                |    |
+    ||          ||                    \|/   |(2)         
+    ||          ||                +---------------+   
+    ||          ||                |  Transmission | 
+    \\==========================> |      Queue    |==============>
+        Encoded Video Packets     +---------------+   Outgoing  
+                                                       Packets     
           
 ]]></artwork>
-        </figure></t>
+          </figure></t>
 
-
-<t><xref target="fig-rmcat-solution-multi-stream"></xref> shows an example
-configuration for multiple video streams sharing a common Network Congestion
-Controller (NCC). The NCC calculates an aggregated estimated available
-bandwidth (1) based on periodic RTCP feedback reports and Shared States (?). 
-Based on such information and occupancy level of the transmission
-queue for each substream (2), the Rate Controller divides up the aggregate
-estimated bandwidth amongst sub-streams based on their relative priority levels, 
-and subsequently regulates the sending rate of each Transmission Queue (3), 
-target video rate (4), and FEC/padding rate (5) for each sub-stream. For
-sake of abrevity the role of FEC/padding packet generators are omitted
-in the above figure.   </t>
-    
-</section>
-
-</section>
+        <t><xref target="fig-rmcat-solution-multi-stream"></xref> shows an
+        example configuration for multiple video streams sharing a common
+        Network Congestion Controller. The Network Congestion Controller
+        calculates an aggregated estimated available bandwidth (1) based on
+        periodic RTCP feedback reports and Shared States. Based on such
+        information and occupancy level of the transmission queue for each sub
+        stream (2), the Rate Controller divides up the aggregate estimated
+        bandwidth amongst sub-streams based on their relative priority levels,
+        and subsequently regulates the sending rate of each Transmission Queue
+        (3), target video rate (4). For sake of simplicity the role of network
+        probe is omitted in the above figure.</t>
+      </section>
+    </section>
 
     <section anchor="Acknowledgements" title="Acknowledgements">
       <t>The RMCAT design team discussions contributed to this memo.</t>
@@ -376,11 +335,6 @@ in the above figure.   </t>
     <references title="Normative References">
       <?rfc include="reference.I-D.ietf-rmcat-cc-requirements"?>
 
-      <?rfc include="reference.I-D.ietf-rmcat-eval-criteria"?>
-
-      <?rfc include="reference.I-D.ietf-avtcore-rtp-circuit-breakers"
-?>
-
       <?rfc include="reference.RFC.2119"?>
 
       <?rfc include="reference.RFC.3550"?>
@@ -390,32 +344,10 @@ in the above figure.   </t>
       <?rfc include="reference.RFC.4585"?>
 
       <?rfc include="reference.RFC.5104"?>
-
-      <?rfc include="reference.RFC.4566"?>
-
-      <?rfc include="reference.RFC.5506"?>
-
-      <?rfc include="reference.RFC.5761"?>
-
-      <?rfc include="reference.RFC.5450"?>
     </references>
 
     <references title="Informative References">
       <?rfc include="reference.RFC.0768"?>
-
-      <?rfc include="reference.RFC.5681"?>
-
-      <?rfc include="reference.RFC.4340"?>
-
-      <?rfc include="reference.RFC.5348"?>
-
-      <?rfc include="reference.RFC.5109"?>
-
-      <?rfc include="reference.RFC.6865"?>
-
-      <?rfc include="reference.RFC.6330"?>
-
-      <?rfc ?>
     </references>
   </back>
 </rfc>


### PR DESCRIPTION
 typo fix, re-nameed FEC module -> Network probe, redrawn multi stream… example and changed text for both single and multi-stream example, removed non-referenced items from References section, changed Area from RAI -> transport, some more editorial changes
